### PR TITLE
Add package manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+recursive-include rapids_cli *.py
+recursive-include rapids_cli *.yml
+
+include README.md
+include requirements.txt
+include MANIFEST.in
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
By default Python only packages up `.py` files for distribution. We are storing our config in a `.yml` file so we need to ensure that this gets included too.

Also just added a few standard options too for good measure.