### PR TITLE
Drop `prefix` from `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,4 +29,3 @@ dependencies:
       - rich==13.8.1
       - PyYAML==6.0.2
       - yml==0.0.1
-prefix: /opt/miniconda3/envs/rapids-env


### PR DESCRIPTION
As `name` is already specified, Conda will just use that. The only reason to use `prefix` is to specify a particular `path`. Though that shouldn't be needed by users of this environment file (and the path could be off for them if it doesn't exist).