### PR TITLE
Remove prettier from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,6 @@ repos:
         additional_dependencies:
           - black==23.1.0
         args: [--skip-errors]
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
-    hooks:
-      - id: prettier
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.43.0
     hooks:


### PR DESCRIPTION
The prettier pre-commit hook is archived and we don't really have many files that benefit from its formatting.