### PR TITLE
Add `rapids run` subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+rmm_log.txt

--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@ in a quick and scriptable way.
 
 ```console
 $ rapids --help
+                                                                                      
+ Usage: rapids [OPTIONS] COMMAND [ARGS]...                                            
+                                                                                      
+ The Rapids CLI is a command-line interface for RAPIDS.                               
+                                                                                      
+╭─ Options ──────────────────────────────────────────────────────────────────────────╮
+│ --help      Show this message and exit.                                            │
+╰────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────╮
+│ doctor    Run health checks to ensure RAPIDS is installed correctly.               │
+│ run       Run a Python script with RAPIDS Accelerator Modes enabled.               │
+╰────────────────────────────────────────────────────────────────────────────────────╯
 
- Usage: rapids [OPTIONS] COMMAND [ARGS]...                                             
-
- The Rapids CLI is a command-line interface for RAPIDS.
-
-╭─ Options ───────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                             │
-╰─────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ──────────────────────────────────────────────────────────────────────────╮
-│ doctor    Run health checks to ensure RAPIDS is installed correctly.                │
-╰─────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## RAPIDS Doctor

--- a/rapids_cli/cli.py
+++ b/rapids_cli/cli.py
@@ -4,6 +4,7 @@ import rich_click as click
 from rich.console import Console
 from rich.traceback import install
 
+import rapids_cli.run
 from rapids_cli.doctor import doctor_check
 
 console = Console()
@@ -26,6 +27,25 @@ def doctor(verbose, filters):
     status = doctor_check(verbose, filters)
     if not status:
         raise click.ClickException("Health checks failed.")
+
+
+@rapids.command(help="Run a Python script with RAPIDS Accelerator Modes enabled.")
+@click.option("-m", "module")
+@click.option("-c", "cmd")
+@click.option(
+    "--profile",
+    is_flag=True,
+    help="Perform per-function profiling of this script.",
+)
+@click.option(
+    "--line-profile",
+    is_flag=True,
+    help="Perform per-line profiling of this script.",
+)
+@click.argument("args", nargs=-1)
+def run(module, cmd, profile, line_profile, args):
+    """Run a Python script with RAPIDS Accelerator Modes enabled."""
+    rapids_cli.run.run(module, cmd, profile, line_profile, args)
 
 
 if __name__ == "__main__":

--- a/rapids_cli/run.py
+++ b/rapids_cli/run.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Run a Python script with RAPIDS Accelerator Modes enabled.
+
+Usage:
+
+rapids run <script.py> <args>
+rapids run -m module <args>
+"""
+
+import code
+import runpy
+import sys
+import tempfile
+from contextlib import contextmanager
+
+from cudf.pandas import install
+from cudf.pandas.profiler import Profiler, lines_with_profiling
+
+
+@contextmanager
+def profile_cm(function_profile, line_profile, fn):
+    """Context manager for profiling."""
+    if fn is None and (line_profile or function_profile):
+        raise RuntimeError("Enabling the profiler requires a script name.")
+    if line_profile:
+        with open(fn) as f:
+            lines = f.readlines()
+
+        with tempfile.NamedTemporaryFile(mode="w+b", suffix=".py") as f:
+            f.write(lines_with_profiling(lines, function_profile).encode())
+            f.seek(0)
+
+            yield f.name
+    elif function_profile:
+        with Profiler() as profiler:
+            yield fn
+        profiler.print_per_function_stats()
+    else:
+        yield fn
+
+
+def run(module, cmd, profile, line_profile, args):
+    """Run a Python script with RAPIDS Accelerator Modes enabled."""
+    args = list(args)
+
+    if cmd:
+        f = tempfile.NamedTemporaryFile(mode="w+b", suffix=".py")
+        f.write(cmd[0].encode())
+        f.seek(0)
+        args.insert(0, f.name)
+
+    install()
+
+    script_name = args[0] if len(args) > 0 else None
+    with profile_cm(profile, line_profile, script_name) as fn:
+        if script_name is not None:
+            args[0] = fn
+        if module:
+            (module,) = module
+            # run the module passing the remaining arguments
+            # as if it were run with python -m <module> <args>
+            sys.argv[:] = [module, *args]  # not thread safe?
+            runpy.run_module(module, run_name="__main__")
+        elif len(args) >= 1:
+            # Remove ourself from argv and continue
+            sys.argv[:] = args
+            runpy.run_path(args[0], run_name="__main__")
+        else:
+            if sys.stdin.isatty():
+                banner = f"Python {sys.version} on {sys.platform}"
+                site_import = not sys.flags.no_site
+                if site_import:
+                    cprt = 'Type "help", "copyright", "credits" or "license" for more information.'
+                    banner += "\n" + cprt
+            else:
+                # Don't show prompts or banners if stdin is not a TTY
+                sys.ps1 = ""
+                sys.ps2 = ""
+                banner = ""
+
+            # Launch an interactive interpreter
+            code.interact(banner=banner, exitmsg="")


### PR DESCRIPTION
Adds a `rapids run` command which lets you run a Python script with RAPIDS Accelerater Modes enabled.

For now this is just a modified version of [`python -m cudf.pandas`](https://github.com/rapidsai/cudf/blob/ed2f3c3033c5616a1d3b888f78ef10187add92d3/python/cudf/cudf/pandas/__main__.py) with `argparse` ported over to `click`.

In the future more accelerated modes could be loaded and enabled by default.

```console
$ rapids run --profile /tmp/cudf_pandas_nyc_parking_demo.py
Calculate violations by state took: 2.610 seconds
Calculate violations by vehicle type took: 0.099 seconds
Calculate violations by day of week took: 0.782 seconds

                                                                                                                    
                                             Total time elapsed: 26.837 seconds                                     
                                          212 GPU function calls in 25.766 seconds                                  
                                           0 CPU function calls in 0.000 seconds                                    
                                                                                                                    
                                                           Stats                                                    
                                                                                                                    
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Function                       ┃ GPU ncalls ┃ GPU cumtime ┃ GPU percall ┃ CPU ncalls ┃ CPU cumtime ┃ CPU percall ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ read_parquet                   │ 1          │ 20.782      │ 20.782      │ 0          │ 0.000       │ 0.000       │
│ DataFrame.__getitem__          │ 30         │ 0.037       │ 0.001       │ 0          │ 0.000       │ 0.000       │
│ DataFrame.value_counts         │ 10         │ 2.605       │ 0.261       │ 0          │ 0.000       │ 0.000       │
│ Series.groupby                 │ 10         │ 0.005       │ 0.001       │ 0          │ 0.000       │ 0.000       │
│ GroupBy.head                   │ 10         │ 0.766       │ 0.077       │ 0          │ 0.000       │ 0.000       │
│ Series.sort_index              │ 10         │ 0.293       │ 0.029       │ 0          │ 0.000       │ 0.000       │
│ Series.reset_index             │ 10         │ 0.011       │ 0.001       │ 0          │ 0.000       │ 0.000       │
│ DataFrame.groupby              │ 20         │ 0.009       │ 0.000       │ 0          │ 0.000       │ 0.000       │
│ DataFrameGroupBy.aggregate     │ 10         │ 0.120       │ 0.012       │ 0          │ 0.000       │ 0.000       │
│ DataFrame.rename               │ 10         │ 0.010       │ 0.001       │ 0          │ 0.000       │ 0.000       │
│ DataFrame.sort_values          │ 10         │ 0.033       │ 0.003       │ 0          │ 0.000       │ 0.000       │
│ NDFrame.astype                 │ 10         │ 0.087       │ 0.009       │ 0          │ 0.000       │ 0.000       │
│ DataFrame.__setitem__          │ 20         │ 0.018       │ 0.001       │ 0          │ 0.000       │ 0.000       │
│ Series                         │ 10         │ 0.001       │ 0.000       │ 0          │ 0.000       │ 0.000       │
│ CombinedDatetimelikeProperties │ 1          │ 0.000       │ 0.000       │ 0          │ 0.000       │ 0.000       │
│ Series.map                     │ 10         │ 0.752       │ 0.075       │ 0          │ 0.000       │ 0.000       │
│ DataFrameGroupBy.__getitem__   │ 10         │ 0.020       │ 0.002       │ 0          │ 0.000       │ 0.000       │
│ GroupBy.count                  │ 10         │ 0.173       │ 0.017       │ 0          │ 0.000       │ 0.000       │
│ Series.sort_values             │ 10         │ 0.043       │ 0.004       │ 0          │ 0.000       │ 0.000       │
└────────────────────────────────┴────────────┴─────────────┴─────────────┴────────────┴─────────────┴─────────────┘
```