### PR TITLE
refactor: restrict try-except blocks to lines that raise exceptions

### DIFF
--- a/rapids_cli/doctor/checks/gpu.py
+++ b/rapids_cli/doctor/checks/gpu.py
@@ -10,32 +10,31 @@ def gpu_check(verbose=False):
     """Check GPU availability."""
     try:
         pynvml.nvmlInit()
-        num_gpus = pynvml.nvmlDeviceGetCount()
-        return f"GPU(s) detected: {num_gpus}"
     except pynvml.NVMLError as e:
         raise ValueError("No available GPUs detected") from e
+    num_gpus = pynvml.nvmlDeviceGetCount()
+    return f"GPU(s) detected: {num_gpus}"
 
 
 def check_gpu_compute_capability(verbose):
     """Check the system for GPU Compute Capability."""
     try:
-        required_capability = 7
         pynvml.nvmlInit()
-
-        num_gpus = pynvml.nvmlDeviceGetCount()
-        for i in range(num_gpus):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-            major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
-            compute_capability = major * 10 + minor
-
-            if compute_capability >= required_capability:
-                continue
-            else:
-                raise ValueError(
-                    f"GPU {i} does not meet the required compute "
-                    f"capability {required_capability[0]}.{required_capability[1]}."
-                )
-        return True
-
     except pynvml.NVMLError as e:
         raise ValueError("No GPU - cannot determineg GPU Compute Capability") from e
+
+    required_capability = 7
+    num_gpus = pynvml.nvmlDeviceGetCount()
+    for i in range(num_gpus):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+        major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
+        compute_capability = major * 10 + minor
+
+        if compute_capability >= required_capability:
+            continue
+        else:
+            raise ValueError(
+                f"GPU {i} does not meet the required compute "
+                f"capability {required_capability[0]}.{required_capability[1]}."
+            )
+    return True

--- a/rapids_cli/doctor/checks/memory.py
+++ b/rapids_cli/doctor/checks/memory.py
@@ -38,17 +38,16 @@ def check_memory_to_gpu_ratio(verbose=True):
     """
     try:
         pynvml.nvmlInit()
-        system_memory = get_system_memory(verbose)
-        gpu_memory = get_gpu_memory(verbose)
-        ratio = system_memory / gpu_memory
-        if ratio >= 1.8:
-            return True
-        else:
-            warnings.warn(
-                "System Memory to total GPU Memory ratio not at least 2:1 ratio. "
-                "It is recommended to have double the system memory to GPU memory for optimal performance.",
-                stacklevel=2,
-            )
-            return True
     except pynvml.NVMLError as e:
         raise ValueError("GPU not found. Please ensure GPUs are installed.") from e
+
+    system_memory = get_system_memory(verbose)
+    gpu_memory = get_gpu_memory(verbose)
+    ratio = system_memory / gpu_memory
+    if ratio < 1.8:
+        warnings.warn(
+            "System Memory to total GPU Memory ratio not at least 2:1 ratio. "
+            "It is recommended to have double the system memory to GPU memory for optimal performance.",
+            stacklevel=2,
+        )
+    return True

--- a/rapids_cli/doctor/checks/nvlink.py
+++ b/rapids_cli/doctor/checks/nvlink.py
@@ -10,17 +10,18 @@ def check_nvlink_status(verbose=True):
     """Check the system for NVLink with 2 or more GPUs."""
     try:
         pynvml.nvmlInit()
-        device_count = pynvml.nvmlDeviceGetCount()
-        if device_count < 2:
-            return False
-
-        for i in range(device_count):
-            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
-            for nvlink_id in range(pynvml.NVML_NVLINK_MAX_LINKS):
-                try:
-                    pynvml.nvmlDeviceGetNvLinkState(handle, 0)
-                    return True
-                except pynvml.NVMLError as e:
-                    raise ValueError(f"NVLink {nvlink_id} Status Check Failed") from e
     except pynvml.NVMLError as e:
         raise ValueError("GPU not found. Please ensure GPUs are installed.") from e
+
+    device_count = pynvml.nvmlDeviceGetCount()
+    if device_count < 2:
+        return False
+
+    for i in range(device_count):
+        handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+        for nvlink_id in range(pynvml.NVML_NVLINK_MAX_LINKS):
+            try:
+                pynvml.nvmlDeviceGetNvLinkState(handle, 0)
+                return True
+            except pynvml.NVMLError as e:
+                raise ValueError(f"NVLink {nvlink_id} Status Check Failed") from e

--- a/rapids_cli/doctor/checks/os.py
+++ b/rapids_cli/doctor/checks/os.py
@@ -70,25 +70,24 @@ def detect_os(verbose=False):
                 result = subprocess.check_output(
                     ["wsl", "--list", "--verbose"], text=True
                 )
-                if "Version 2" in result:
-                    valid_os = True
             except FileNotFoundError as e:
                 raise ValueError("WSL is not installed") from e
             except subprocess.CalledProcessError as e:
                 raise ValueError("Error checking WSL version") from e
+            if "Version 2" in result:
+                valid_os = True
     elif system == "Linux":
-
         # Check for specific Linux distributions
         try:
             with open("/etc/os-release") as f:
                 os_release = f.read()
-                os_attributes = get_os_attributes(os_release)
-                os = get_os_attributes(os_release)["NAME"]
-                valid_os = check_os_version(os_attributes, verbose)
         except FileNotFoundError as e:
             raise ValueError(
                 "/etc/os-release file not found. This might not be a typical Linux environment."
             ) from e
+        os_attributes = get_os_attributes(os_release)
+        os = get_os_attributes(os_release)["NAME"]
+        valid_os = check_os_version(os_attributes, verbose)
     else:
         raise ValueError("Operating System not recognized")
 
@@ -96,6 +95,5 @@ def detect_os(verbose=False):
         return True
     else:
         raise ValueError(
-            f"OS {os} is not compatible with RAPIDS. "
-            "Please see https://docs.rapids.ai/install for system requirements."
+            f"OS {os} is not compatible with RAPIDS. Please see https://docs.rapids.ai/install for system requirements."
         )


### PR DESCRIPTION
This is a small, hopefully focused, refactoring pass.

Try-except loops should try to limit the contents of the `try` block to only those lines which will raise the Exceptions that we're looking for in the `except`
