### PR TITLE
remove unused dependencies, fix undeclared dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "nvidia-ml-py",
     "pytest",
 ]
 


### PR DESCRIPTION
Contributes to #89 and #90

The project's metadata currently does not match the code. This fixes that in the following ways:

* removes references to dependencies that are not used or only used indirectly
* adds references to previously-omitted required dependencies (like `packaging`)
* removes references to `pynvml` in favor of `nvidia-ml-py` (see https://github.com/rapidsai/build-planning/issues/17 and https://github.com/rapidsai/dask-cuda/issues/1117#issuecomment-1450647355)