### PR TITLE
run 'mypy' via pre-commit, enforce 'pre-commit' checks in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
     hooks:
@@ -26,7 +30,6 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
-      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.13.0'
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,10 @@ conda = "rapids_cli.doctor.checks.dependencies:check_conda"
 pip = "rapids_cli.doctor.checks.dependencies:check_pip"
 glb = "rapids_cli.doctor.checks.dependencies:check_glb"
 
+[tool.black]
+# this should match the oldest version of Python the library supports
+target-version = ["py310"]
+
 [tool.pytest]
 testpaths = ["tests"]
 

--- a/rapids_cli/cli.py
+++ b/rapids_cli/cli.py
@@ -20,7 +20,9 @@ def rapids():
 
 
 @rapids.command()
-@click.option("--verbose", is_flag=True, help="Enable verbose mode for detailed output.")
+@click.option(
+    "--verbose", is_flag=True, help="Enable verbose mode for detailed output."
+)
 @click.argument("filters", nargs=-1)
 def doctor(verbose, filters):
     """Run health checks to ensure RAPIDS is installed correctly."""

--- a/rapids_cli/doctor/checks/dependencies.py
+++ b/rapids_cli/doctor/checks/dependencies.py
@@ -15,14 +15,18 @@ from rapids_cli.doctor.checks.os import detect_os
 def check_conda(verbose=False):
     """Check the system for Conda compatibility."""
     conda_requirement = config["min_supported_versions"]["conda_requirement"]
-    result = subprocess.check_output(["conda", "info", "--json"], stderr=subprocess.DEVNULL)
+    result = subprocess.check_output(
+        ["conda", "info", "--json"], stderr=subprocess.DEVNULL
+    )
     result_json = json.loads(result.decode("utf-8"))
     version_num = result_json["conda_version"]
 
     if version_num >= conda_requirement:
         return True
     else:
-        raise ValueError(f"CONDA Version is not compatible with RAPIDS - please upgrade to conda {conda_requirement}")
+        raise ValueError(
+            f"CONDA Version is not compatible with RAPIDS - please upgrade to conda {conda_requirement}"
+        )
 
 
 def check_pip(verbose=False):
@@ -30,7 +34,9 @@ def check_pip(verbose=False):
     system_cuda_version = get_cuda_version()
     if not system_cuda_version:
         return
-    result = subprocess.check_output(["pip", "show", "cuda-python"], stderr=subprocess.DEVNULL)
+    result = subprocess.check_output(
+        ["pip", "show", "cuda-python"], stderr=subprocess.DEVNULL
+    )
     pip_cuda_version = result.decode("utf-8").strip().split("\n")[1].split(" ")[-1]
     system_cuda_version_major, pip_cuda_version_major = (
         system_cuda_version.split(".")[0],
@@ -39,14 +45,18 @@ def check_pip(verbose=False):
     if system_cuda_version_major >= pip_cuda_version_major:
         return True
     else:
-        raise ValueError(f"Please upgrade pip CUDA version to {system_cuda_version_major}")
+        raise ValueError(
+            f"Please upgrade pip CUDA version to {system_cuda_version_major}"
+        )
 
 
 def check_docker(verbose=False):
     """Check the system for Docker compatibility."""
     docker_requirement = config["min_supported_versions"]["docker_requirement"]
     docker_version_data = json.loads(
-        subprocess.check_output(["docker", "version", "-f", "json"], stderr=subprocess.DEVNULL)
+        subprocess.check_output(
+            ["docker", "version", "-f", "json"], stderr=subprocess.DEVNULL
+        )
     )
     if docker_version_data["Server"]["Version"] >= docker_requirement:
         return True

--- a/rapids_cli/doctor/checks/os.py
+++ b/rapids_cli/doctor/checks/os.py
@@ -67,7 +67,9 @@ def detect_os(verbose=False):
         os = "Windows"
         if release == "11":
             try:
-                result = subprocess.check_output(["wsl", "--list", "--verbose"], text=True)
+                result = subprocess.check_output(
+                    ["wsl", "--list", "--verbose"], text=True
+                )
             except FileNotFoundError as e:
                 raise ValueError("WSL is not installed") from e
             except subprocess.CalledProcessError as e:
@@ -80,7 +82,9 @@ def detect_os(verbose=False):
             with open("/etc/os-release") as f:
                 os_release = f.read()
         except FileNotFoundError as e:
-            raise ValueError("/etc/os-release file not found. This might not be a typical Linux environment.") from e
+            raise ValueError(
+                "/etc/os-release file not found. This might not be a typical Linux environment."
+            ) from e
         os_attributes = get_os_attributes(os_release)
         os = get_os_attributes(os_release)["NAME"]
         valid_os = check_os_version(os_attributes, verbose)

--- a/rapids_cli/doctor/doctor.py
+++ b/rapids_cli/doctor/doctor.py
@@ -55,7 +55,9 @@ def doctor_check(verbose: bool, filters: list[str] | None = None) -> bool:
     > doctor_check(['cudf'])  # Run 'cudf' specific checks
     """
     filters = [] if not filters else filters
-    console.print(f"[bold green]{DOCTOR_SYMBOL} Performing REQUIRED health check for RAPIDS [/bold green]")
+    console.print(
+        f"[bold green]{DOCTOR_SYMBOL} Performing REQUIRED health check for RAPIDS [/bold green]"
+    )
 
     checks = []
     if verbose:


### PR DESCRIPTION
Fixes #39 
Fixes #36

Changes:

* adds a CI job that runs `pre-commit`
* improvements to `pr.yaml`:
  - only running tests on PRs (not merges to `main`)
  - automatically cancelling in-progress runs when a new commit is pushed
  - updates workflow name to just `pr` (to make the checks summary on PRs a little easier to read, and for consistency with other RAPIDS repos)
* removes unused configuration from `pyproject.toml` (looks like some of this may have just been copied over from other projects)
* fixes `mypy` warnings:
* adds `mypy` hook to `pre-commit` configuration

```text
rapids_cli/doctor/doctor.py:23: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
rapids_cli/doctor/doctor.py:24: error: Incompatible types in assignment (expression has type "None", variable has type "Exception")  [assignment]
rapids_cli/doctor/doctor.py:25: error: Incompatible types in assignment (expression has type "None", variable has type "list[Warning]")  [assignment]
rapids_cli/doctor/doctor.py:97: error: Argument "value" to "CheckResult" has incompatible type "None"; expected "str"  [arg-type]
rapids_cli/doctor/doctor.py:98: error: Argument "error" to "CheckResult" has incompatible type "Exception | None"; expected "Exception"  [arg-type]
rapids_cli/doctor/doctor.py:99: error: Argument "warnings" to "CheckResult" has incompatible type "list[WarningMessage] | None"; expected "list[Warning]"  [arg-type]
rapids_cli/doctor/doctor.py:107: error: "Warning" has no attribute "message"  [attr-defined]
```