### PR TITLE
build and test wheels in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
+  workflow_dispatch:
+    inputs:
+      branch:
+        required: true
+        type: string
+      date:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+      build_type:
+        type: string
+        default: nightly
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  wheel-build:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      script: ci/build_wheel.sh
+      # only need 1 build: amd64, oldest-supported Python, latest-supported CUDA
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+      package-name: rapids-cli
+      package-type: python
+      pure-wheel: true
+      append-cuda-suffix: false
+  wheel-publish:
+    needs: wheel-build
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    with:
+      build_type: ${{ inputs.build_type || 'branch' }}
+      branch: ${{ inputs.branch }}
+      sha: ${{ inputs.sha }}
+      date: ${{ inputs.date }}
+      package-name: rapids-cli
+      package-type: python

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,24 +2,12 @@ name: build
 
 on:
   push:
+    # run on every new commit pushed to 'main'
     branches:
       - main
+    # run whenever a new tag is created following one of the following patterns
     tags:
       - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
-  workflow_dispatch:
-    inputs:
-      branch:
-        required: true
-        type: string
-      date:
-        required: true
-        type: string
-      sha:
-        required: true
-        type: string
-      build_type:
-        type: string
-        default: nightly
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -30,10 +18,7 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
+      build_type: branch
       script: ci/build_wheel.sh
       # only need 1 build: amd64, oldest-supported Python, latest-supported CUDA
       matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
@@ -46,9 +31,6 @@ jobs:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
     with:
-      build_type: ${{ inputs.build_type || 'branch' }}
-      branch: ${{ inputs.branch }}
-      sha: ${{ inputs.sha }}
-      date: ${{ inputs.date }}
+      build_type: branch
       package-name: rapids-cli
       package-type: python

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,7 +22,7 @@ jobs:
       pure-wheel: true
       append-cuda-suffix: false
   wheel-tests:
-    needs: [conda-cpp-build, changed-files]
+    needs: [build-wheel]
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
     with:
@@ -30,4 +30,4 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/citestwheel:latest"
-      run_script: "ci/test_wheel.sh"
+      run_script: ci/test_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,14 @@
-name: Python Tests
+name: pr
 
 on:
   push:
     branches:
-      - main
-  pull_request:
+      - "pull-request/[0-9]+"
+
+# automatically cancel in-progress CI runs if a new commit is pushed to the same ref
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   build-wheel:
@@ -21,6 +25,7 @@ jobs:
   wheel-tests:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    needs: [build-wheel]
     with:
       build_type: pull-request
       script: ci/test_wheel.sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,15 +7,22 @@ on:
   pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[test]
-      - name: Run tests
-        run: pytest
+  build-wheel:
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    with:
+      build_type: pull-request
+      script: ci/build_wheel.sh
+      # only need 1 build: amd64, oldest-supported Python, latest-supported CUDA
+      matrix_filter: '[map(select(.ARCH == "amd64")) | min_by((.PY_VER | split(".") | map(tonumber)), (.CUDA_VER | split(".") | map(-tonumber)))]'
+      package-name: rapids-cli
+      package-type: python
+      pure-wheel: true
+      append-cuda-suffix: false
+  wheel-tests:
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
+    with:
+      build_type: pull-request
+      script: ci/test_wheel.sh
+      # run just 1 amd64 and 1 arm64 test job (using the oldest-supported Python and the latest-supported CUDA)
+      matrix_filter: group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,11 +22,12 @@ jobs:
       pure-wheel: true
       append-cuda-suffix: false
   wheel-tests:
+    needs: [conda-cpp-build, changed-files]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-25.06
-    needs: [build-wheel]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
     with:
       build_type: pull-request
-      script: ci/test_wheel.sh
-      # run just 1 amd64 and 1 arm64 test job (using the oldest-supported Python and the latest-supported CUDA)
-      matrix_filter: group_by(.CUDA_VER|split(".")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(".")|map(tonumber)), (.CUDA_VER|split(".")|map(tonumber))]))
+      node_type: "gpu-l4-latest-1"
+      arch: "amd64"
+      container_image: "rapidsai/citestwheel:latest"
+      run_script: "ci/test_wheel.sh"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - "pull-request/[0-9]+"
 
-# automatically cancel in-progress CI runs if a new commit is pushed to the same ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+*.bz2
+*.conda
 .mypy_cache/
 .ruff_cache/
+*.tar.gz
+*.whl
+*.zip
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+python -m pip wheel                     \
+    -v                                  \
+    --no-deps                           \
+    --disable-pip-version-check         \
+    -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
+    .

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -5,6 +5,6 @@ WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rapids_cli" RAPIDS_PY_WHEEL_PURE="1" rapids-d
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-    "$(echo "${WHEELHOUSE}/rapids_cli"*.whl)[test]"
+    $(echo "${WHEELHOUSE}/rapids_cli"*.whl)[test]
 
 python -m pytest

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # nx-cugraph is a pure wheel, which is part of generating the download path
-WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rapids_cli" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
+WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rapids-cli" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-    $(echo "${WHEELHOUSE}/rapids_cli"*.whl)[test]
+    "$(echo "${WHEELHOUSE}"/rapids_cli*.whl)[test]"
 
 python -m pytest

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# nx-cugraph is a pure wheel, which is part of generating the download path
+WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rapids_cli" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
+
+# echo to expand wildcard before adding `[extra]` requires for pip
+rapids-pip-retry install \
+    "$(echo "${WHEELHOUSE}/rapids_cli"*.whl)[test]"
+
+python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = [
+    "setuptools>=64.0.0",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "rapids_cli"
+name = "rapids-cli"
 version = "0.1"
 description = "A CLI for RAPIDS"
 requires-python = ">=3.10"


### PR DESCRIPTION
Fixes #90 

* adds wheels CI (for PRs and branch builds)
* changes the distribution name from `rapids_cli` (underscore) to `rapids-cli` (hyphen), so the experience will be e.g. `pip install rapids-cli`
* puts a floor on `setuptools`, to ensure builds always get a version that supports `pyproject.toml`
* sets up tests to run on CI runners with GPUs
  - *I expect we'll want this as the test suite here is expanded*

## Notes for Reviewers

### Why use the RAPIDS calendar-versioned workflows?

I think it's useful here to reuse all the RAPIDS machinery, especially artifact-handling and running tests on runners with GPUs.

This project differs in this important way from other pure-Python, `main`-branch projects in RAPIDS like https://github.com/rapidsai/rapids-build-backend or https://github.com/rapidsai/rapids-metadata ... something like https://github.com/rapidsai/dask-cuda is probably a better reference for the testing needs for this project.

Maybe we'll want to revisit this in the future as we see how often this project gets released relative to RAPIDS, but I think this is a good starting point for now.