### PR TITLE
upload wheels to downloads.rapids.ai

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,3 +9,5 @@ python -m pip wheel                     \
     --disable-pip-version-check         \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     .
+
+RAPIDS_PY_WHEEL_NAME="rapids-cli" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
After I merged #95, saw uploads to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/ fail like this:

```text
jq: error (at <unknown>): Cannot iterate over null (null)
Using Anaconda API: https://api.anaconda.org/
Error:  ('Authentication token is missing. Please, use `anaconda login` to reauthenticate.', 401)
```

([build link](https://github.com/rapidsai/rapids-cli/actions/runs/15184064755/job/42700655043)

I forgot that the upload workflows still expect to find wheel artifacts in S3.
That'll change with https://github.com/rapidsai/shared-workflows/pull/332 in the 25.08 release, but for now we still need to upload to S3.

This adds that upload, to hopefully fix publishing to https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/
