### PR TITLE
switch from 'run_script' to 'script' in GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,4 +38,4 @@ jobs:
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
       container_image: "rapidsai/citestwheel:latest"
-      run_script: ci/test_wheel.sh
+      script: ci/test_wheel.sh


### PR DESCRIPTION
Closes https://github.com/rapidsai/shared-workflows/issues/337

* switches from input `run_script` to `script` in uses of the `custom-job` workflow