### PR TITLE
stop uploading packages to downloads.rapids.ai, update to 25.08 workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   wheel-build:
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
     with:
       build_type: branch
       script: ci/build_wheel.sh
@@ -29,7 +29,7 @@ jobs:
   wheel-publish:
     needs: wheel-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-publish.yaml@branch-25.08
     with:
       build_type: branch
       package-name: rapids-cli

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
   build-wheel:
-    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.08
     needs: [checks]
     with:
       build_type: pull-request
@@ -32,7 +32,7 @@ jobs:
   wheel-tests:
     needs: [build-wheel]
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.06
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.08
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -9,5 +9,3 @@ python -m pip wheel                     \
     --disable-pip-version-check         \
     -w "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" \
     .
-
-RAPIDS_PY_WHEEL_NAME="rapids-cli" rapids-upload-wheels-to-s3 python "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/181

* removes all uploads of conda packages and wheels to `downloads.rapids.ai`
* updates all `shared-workflows` references to `branch-25.08`, to pull in changes from https://github.com/rapidsai/shared-workflows/pull/364

## Notes for Reviewers

### How I identified changes

Looked for uses of the relevant `gha-tools` tools, as well as documentation about `downloads.rapids.ai`, being on the NVIDIA VPN, using S3, etc. like this:

```shell
git grep -i -E 's3|upload|downloads\.rapids|vpn'
```

### How I tested this

See "How I tested this" on https://github.com/rapidsai/shared-workflows/pull/364

### Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
