### PR TITLE
fix tag pattern in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
       - main
     # run whenever a new tag is created following one of the following patterns
     tags:
-      - v[0-9][0-9].[0-9][0-9].[0-9][0-9]
+      - v[0-9]+.[0-9]+.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
Contributes to #102 

I'd set up the `build.yaml` CI workflow to be triggered by new tags being pushed... but copied a pattern from RAPIDS that doesn't match the current versioning strategy here:

https://github.com/rapidsai/rapids-cli/blob/189e5c5d322407ec540b7dee09dba4c2b1b33b24/.github/workflows/build.yaml#L8-L10

That doesn't match a version like `0.1.2`, because it expect exactly 2 digits in each version component.

This fixes that.