### PR TITLE
add CODEOWNERS, introduce pr-builder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
+# default reviewers, unless more specific rules below match
 * @rapidsai/deployment-write
+
+# CI code owners
+/.github/                @rapidsai/ci-codeowners
+/ci/                     @rapidsai/ci-codeowners
+
+# packaging code owners
+/.pre-commit-config.yaml @rapidsai/packaging-codeowners
+/conda/                  @rapidsai/packaging-codeowners
+dependencies.yaml        @rapidsai/packaging-codeowners
+pyproject.toml           @rapidsai/packaging-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rapidsai/deployment-write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-builder:
+    needs:
+      - checks
+      - conda-python-build
+      - conda-python-tests
+      - wheel-build
+      - wheel-tests
+    secrets: inherit
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.08
+    if: always()
+    with:
+      needs: ${{ toJSON(needs) }}
   checks:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #100

Introduces a couple of governance changes.

## Introducing a `pr-builder` workflow

This simplifies setting up a branch protection to get behavior like "all CI has to be pass before a PR can be merged".

See the discussion in https://github.com/orgs/community/discussions/26733 for some background.

Summary:

* GitHub Actions branch protections require you to list individual checks that must pass, by name
* doing that requires access to the repo settings
* most developers don't have access to the repo settings

Across RAPIDS, we solve this by using a workflow whose only function is to just depend on other workflows.
That way, the repo settings only need to be changed once, and then developers can add and remove required jobs by modifying the `needs:` list in the `pr-builder` call.

## Setting up CODEOWNERS

This can be used to set up automatic reviewers on PRs, so we don't have to manually add people.

For now, I'm proposing:

* by default, all PRs require 1 approval from @rapidsai/deployment-write 
* PRs only touching a specific subset of files could be merged with an approval from `@rapidsai/ci-codeowners` or `@rapidsai/packaging-codeowners`
  - *we've done this across RAPIDS, it's useful for stuff like "the build-infra team is switching all uses of `conda` to `mamba`" type of stuff*

@ncclementi @jacobtomlinson if you agree with this, I'll get those teams added with write access in the repo here.

If you'd prefer to just have @rapidsai/deployment-write approvals for now, that's fine, up to you.