### PR TITLE
Remove conda entrypoints

### DIFF
--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -31,5 +31,8 @@ rapids-print-env
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+rapids-logger "Checking CLI is available"
+rapids --help
+
 rapids-logger "running tests"
 python -m pytest

--- a/conda/recipes/rapids-cli/recipe.yaml
+++ b/conda/recipes/rapids-cli/recipe.yaml
@@ -22,17 +22,6 @@ build:
   script:
     content: |
       python -m pip install -v .
-  python:
-    entry_points:
-      - driver = rapids_cli.doctor.checks.cuda_driver:check_driver_compatibility
-      - gpu = rapids_cli.doctor.checks.gpu:gpu_check
-      - gpu_compute_capability = rapids_cli.doctor.checks.gpu:check_gpu_compute_capability
-      - cuda = rapids_cli.doctor.checks.cuda_driver:cuda_check
-      - driver_compatibility = rapids_cli.doctor.checks.cuda_driver:check_driver_compatibility
-      - sdd_nvme = rapids_cli.doctor.checks.sdd_nvme:check_sdd_nvme
-      - memory_to_gpu_ratio = rapids_cli.doctor.checks.memory:check_memory_to_gpu_ratio
-      - nvlink_status = rapids_cli.doctor.checks.nvlink:check_nvlink_status
-      - os = rapids_cli.doctor.checks.os:detect_os
 
 requirements:
   host:


### PR DESCRIPTION
Experimenting with removing conda entrypoints to see if the `pyproject.toml` entrypoints are sufficient.

Closes #112 