### PR TITLE
Add dry run flag to rapids doctor

### DIFF
--- a/rapids_cli/cli.py
+++ b/rapids_cli/cli.py
@@ -23,10 +23,15 @@ def rapids():
 @click.option(
     "--verbose", is_flag=True, help="Enable verbose mode for detailed output."
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Perform a dry run without making any changes.",
+)
 @click.argument("filters", nargs=-1)
-def doctor(verbose, filters):
+def doctor(verbose, dry_run, filters):
     """Run health checks to ensure RAPIDS is installed correctly."""
-    status = doctor_check(verbose, filters)
+    status = doctor_check(verbose, dry_run, filters)
     if not status:
         raise click.ClickException("Health checks failed.")
 

--- a/rapids_cli/doctor/doctor.py
+++ b/rapids_cli/doctor/doctor.py
@@ -25,7 +25,9 @@ class CheckResult:
     warnings: list[warnings.WarningMessage] | None
 
 
-def doctor_check(verbose: bool, filters: list[str] | None = None) -> bool:
+def doctor_check(
+    verbose: bool, dry_run: bool, filters: list[str] | None = None
+) -> bool:
     """Perform a health check for RAPIDS.
 
     This function runs a series of checks based on the provided arguments.
@@ -71,7 +73,11 @@ def doctor_check(verbose: bool, filters: list[str] | None = None) -> bool:
             checks += [ep.load()]
     if verbose:
         console.print(f"Discovered {len(checks)} checks")
+    if not dry_run:
         console.print("Running checks")
+    else:
+        console.print("Dry run, skipping checks")
+        return True
 
     results: list[CheckResult] = []
     with console.status("[bold green]Running checks...") as ui_status:


### PR DESCRIPTION
This PR allows you to run `rapids doctor --verbose --dry-run` which will discover the checks registered via entry points, but not actually execute them. Can be helpful for debugging.

```console
$ rapids doctor --verbose --dry-run
🧑‍⚕️ Performing REQUIRED health check for RAPIDS 
Discovering checks
Found check 'cuda' provided by 'rapids_cli.doctor.checks.cuda_driver:cuda_check'
Found check 'driver' provided by 'rapids_cli.doctor.checks.cuda_driver:check_driver_compatibility'
Found check 'driver_compatibility' provided by 'rapids_cli.doctor.checks.cuda_driver:check_driver_compatibility'
Found check 'gpu' provided by 'rapids_cli.doctor.checks.gpu:gpu_check'
Found check 'gpu_compute_capability' provided by 'rapids_cli.doctor.checks.gpu:check_gpu_compute_capability'
Found check 'memory_to_gpu_ratio' provided by 'rapids_cli.doctor.checks.memory:check_memory_to_gpu_ratio'
Found check 'nvlink_status' provided by 'rapids_cli.doctor.checks.nvlink:check_nvlink_status'
Found check 'os' provided by 'rapids_cli.doctor.checks.os:detect_os'
Found check 'sdd_nvme' provided by 'rapids_cli.doctor.checks.sdd_nvme:check_sdd_nvme'
Discovered 9 checks
Dry run, skipping checks
```