### PR TITLE
add codespell for typo-checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.10"
+    rev: "v0.11.13"
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.13.0'
+    rev: 'v1.16.0'
     hooks:
       - id: mypy
         additional_dependencies: [
@@ -59,6 +59,12 @@ repos:
           - --use-current-year
           - --no-extra-eol
           - --detect-license-in-X-top-lines=5
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.18.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All checks passed!
 
 ### Check status
 
-If a check function returns successfuly it is assumed the check was successful, regardless of what was returned.
+If a check function returns successfully it is assumed the check was successful, regardless of what was returned.
 
 To fail a test an exception should be raised, ideally with a helpful message that gives the user actionable
 next steps to resolve the problem.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ include = [
 # this should match the oldest version of Python the library supports
 target-version = ["py310"]
 
+[tool.codespell]
+# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override
+skip = "./.git,./pyproject.toml,./.ruff_cache"
+ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
+builtin = "clear"
+quiet-level = 3
+
 [tool.pytest]
 testpaths = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,9 @@ include = [
 target-version = ["py310"]
 
 [tool.codespell]
-# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override
+# NOTE: pre-commit passes explicit lists of files here, which this skip file list doesn't override.
+#       This is just here for IDEs.
 skip = "./.git,./pyproject.toml,./.ruff_cache"
-ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
-builtin = "clear"
 quiet-level = 3
 
 [tool.pytest]

--- a/rapids_cli/doctor/checks/cuda_driver.py
+++ b/rapids_cli/doctor/checks/cuda_driver.py
@@ -86,5 +86,5 @@ def check_driver_compatibility(verbose=False):
         raise ValueError(
             "CUDA & Driver is not compatible with RAPIDS. "
             "Please see https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html "
-            "for CUDA compatability guidance."
+            "for CUDA compatibility guidance."
         )

--- a/rapids_cli/doctor/checks/gpu.py
+++ b/rapids_cli/doctor/checks/gpu.py
@@ -21,7 +21,7 @@ def check_gpu_compute_capability(verbose):
     try:
         pynvml.nvmlInit()
     except pynvml.NVMLError as e:
-        raise ValueError("No GPU - cannot determineg GPU Compute Capability") from e
+        raise ValueError("No GPU - cannot determine GPU Compute Capability") from e
 
     required_capability = 7
     num_gpus = pynvml.nvmlDeviceGetCount()


### PR DESCRIPTION
While reviewing #109, I noticed a typo (not introduced by that PR, just nearby in the diff):

https://github.com/rapidsai/rapids-cli/blob/c09d50fd750407fe5ca127129617965d5e528632/rapids_cli/doctor/checks/gpu.py#L24

So I wanted to add a typo-checking tool here.
I tried https://github.com/codespell-project/codespell and https://github.com/crate-ci/typos and unfortunately neither caught that specific typo.

But `codespell` did catch a few others, and is widely used across RAPIDS... so this proposes adding it to the `pre-commit` config.

While I'm touching it anyway, also updates all other hooks with `pre-commit autoupdate`.