### PR TITLE
adds flag to publish rapids-cli to pypi

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,3 +46,4 @@ jobs:
       build_type: branch
       package-name: rapids-cli
       package-type: python
+      publish_to_pypi: true


### PR DESCRIPTION
The latest version of rapids-cli on pypi is over [2 months old](https://pypi.org/project/rapids-cli/#history), which is out of sync with the changes made after this date. 

For example, a `rapids doctor` check for explicit driver versions was removed in https://github.com/rapidsai/rapids-cli/pull/107, but upon installing through pip this check still shows up and fails in some situations. 

<img width="1105" height="557" alt="Screenshot 2025-08-19 at 3 17 19 PM" src="https://github.com/user-attachments/assets/7292ea3d-80fd-418f-a626-9ff22b628e05" />

Adding the `publish_to_pypi` flag to the `wheel-publish` job in the `build.yaml` should fix this.