### PR TITLE
Use regular print instead of rich print

### DIFF
--- a/rapids_cli/debug/debug.py
+++ b/rapids_cli/debug/debug.py
@@ -100,7 +100,7 @@ def run_debug(output_format="console"):
     }
 
     if output_format == "json":
-        console.print(json.dumps(debug_info, indent=4))
+        print(json.dumps(debug_info, indent=4))
     else:
         console.print("[bold purple]RAPIDS Debug Information[/bold purple]")
         for key, value in debug_info.items():


### PR DESCRIPTION
The console print was causing strings to be wrapped at 80 characters which is not valid JSON.

**Before**

```console
$ rapids debug --json | jq
parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 29, column 15
```

**After**

```console
$ rapids debug --json | jq
{
  "date": "2025-12-17 11:23:02",
  "platform": "Linux-6.6.105+-x86_64-with-glibc2.35",
  ...
```