### PR TITLE
Fix cuda_toolkit_check driver version and add cuda-bindings dep

### DIFF
--- a/conda/recipes/rapids-cli/recipe.yaml
+++ b/conda/recipes/rapids-cli/recipe.yaml
@@ -31,6 +31,8 @@ requirements:
   run:
     - python
     - importlib-metadata >=4.13.0
+    - cuda-bindings >=12.9.6,!=13.0.*,!=13.1.*
+    - cuda-core >=0.6.0
     - cuda-pathfinder >=1.2.3
     - nvidia-ml-py >=12.0
     - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -62,6 +62,9 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cuda-core >=0.6.0
+          # NVML APIs we use via cuda.core.system landed in cuda-bindings
+          # 12.9.6 (CUDA 12) and 13.2.0 (CUDA 13). The 13.0/13.1
+          # wheels pre-date the 13.x landing and are excluded.
           - cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*
           - nvidia-ml-py>=12.0
           - cuda-pathfinder >=1.2.3

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -62,6 +62,7 @@ dependencies:
       - output_types: [conda, requirements, pyproject]
         packages:
           - cuda-core >=0.6.0
+          - cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*
           - nvidia-ml-py>=12.0
           - cuda-pathfinder >=1.2.3
           - packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*",
     "cuda-core >=0.6.0",
     "cuda-pathfinder >=1.2.3",
     "importlib-metadata >= 4.13.0; python_version < '3.12'",

--- a/rapids_cli/doctor/checks/cuda_toolkit.py
+++ b/rapids_cli/doctor/checks/cuda_toolkit.py
@@ -173,10 +173,6 @@ def _gather_toolkit_info() -> CudaToolkitInfo:  # pragma: no cover
         except (DynamicLibNotFoundError, RuntimeError):
             info.missing_libs.append(soname)
 
-    # Get driver version. Default mode returns the CUDA Driver API version
-    # (e.g. 13 for CUDA 13.0), which is what the toolkit-vs-driver comparison
-    # below expects. kernel_mode=True would return the NVIDIA kernel module
-    # version (e.g. 580) and silently break all comparisons.
     try:
         info.driver_major = get_driver_version()[0]
     except Exception:

--- a/rapids_cli/doctor/checks/cuda_toolkit.py
+++ b/rapids_cli/doctor/checks/cuda_toolkit.py
@@ -173,9 +173,12 @@ def _gather_toolkit_info() -> CudaToolkitInfo:  # pragma: no cover
         except (DynamicLibNotFoundError, RuntimeError):
             info.missing_libs.append(soname)
 
-    # Get driver version
+    # Get driver version. Default mode returns the CUDA Driver API version
+    # (e.g. 13 for CUDA 13.0), which is what the toolkit-vs-driver comparison
+    # below expects. kernel_mode=True would return the NVIDIA kernel module
+    # version (e.g. 580) and silently break all comparisons.
     try:
-        info.driver_major = get_driver_version(kernel_mode=True)[0]
+        info.driver_major = get_driver_version()[0]
     except Exception:
         info.driver_major = None
 

--- a/rapids_cli/tests/test_cuda_toolkit.py
+++ b/rapids_cli/tests/test_cuda_toolkit.py
@@ -172,14 +172,7 @@ def test_check_cuda_home_newer_than_driver():
 
 
 def test_gather_toolkit_info_driver_major_is_cuda_major():
-    """driver_major must be the CUDA Driver API major, not the kernel driver major.
-
-    Regression test: prior code passed kernel_mode=True to get_driver_version,
-    which returns the NVIDIA kernel module version (e.g. 580) and broke every
-    toolkit-vs-driver comparison. Skips when the helper can't run at all
-    (e.g. cuda.pathfinder unavailable, no GPU) so macOS and no-GPU CI runners
-    pass cleanly; on a real GPU host this would have caught the original bug.
-    """
+    """Regression: driver_major must be the CUDA Driver API major, not the kernel driver major."""
     try:
         info = _gather_toolkit_info()
     except Exception as e:

--- a/rapids_cli/tests/test_cuda_toolkit.py
+++ b/rapids_cli/tests/test_cuda_toolkit.py
@@ -8,6 +8,7 @@ import pytest
 from rapids_cli.doctor.checks.cuda_toolkit import (
     CudaToolkitInfo,
     _ctypes_cuda_version,
+    _gather_toolkit_info,
     _get_toolkit_cuda_major,
     cuda_toolkit_check,
 )
@@ -168,3 +169,23 @@ def test_check_cuda_home_newer_than_driver():
     ):
         with pytest.raises(ValueError, match="CUDA_HOME"):
             cuda_toolkit_check(toolkit_info=info)
+
+
+def test_gather_toolkit_info_driver_major_is_cuda_major():
+    """driver_major must be the CUDA Driver API major, not the kernel driver major.
+
+    Regression test: prior code passed kernel_mode=True to get_driver_version,
+    which returns the NVIDIA kernel module version (e.g. 580) and broke every
+    toolkit-vs-driver comparison. Skips when the helper can't run at all
+    (e.g. cuda.pathfinder unavailable, no GPU) so macOS and no-GPU CI runners
+    pass cleanly; on a real GPU host this would have caught the original bug.
+    """
+    try:
+        info = _gather_toolkit_info()
+    except Exception as e:
+        pytest.skip(f"_gather_toolkit_info unavailable on this platform: {e}")
+    if info.driver_major is not None:
+        assert info.driver_major < 100, (
+            f"driver_major={info.driver_major} looks like a kernel driver "
+            f"version, not a CUDA Driver API major"
+        )


### PR DESCRIPTION
## Summary

Two related fixes surfaced while smoke-testing #137 on a fresh Brev box:

- **`cuda_toolkit_check` was reading the kernel driver, not the CUDA driver.** `get_driver_version(kernel_mode=True)` returns the NVIDIA kernel module version (e.g. `580` from `580.126.09`), not the CUDA Driver API version (e.g. `13` from CUDA 13.0). The verbose message also printed `Driver supports CUDA 580`, which is what tipped this off. Dropping `kernel_mode=True` makes `get_driver_version()` default to the CUDA Driver API mode and the comparison logic actually fires.
- **`cuda-bindings` is now declared as a runtime dep, and the conda recipe gets the missing `cuda-core` it should have had since #141.** `cuda-core` calls into `cuda.bindings.driver` via lazy import and without `cuda-bindings` installed, `cuda_toolkit_check` raises `ImportError: cuda.bindings 12.x or 13.x must be installed` on a fresh `pip install rapids-cli`. The pin `>=12.9.6,!=13.0.*,!=13.1.*` excludes the cuda-bindings 13.0/13.1 wheels and is compatible with both CUDA 12 and CUDA 13 driver hosts (verified with cuda-bindings 12.9.6 against a CUDA 13 environment and cuda-bindings 13.2 against a CUDA 12 environment).

A regression test (`test_gather_toolkit_info_driver_major_is_cuda_major`) exercises `_gather_toolkit_info()` end-to-end and asserts `driver_major < 100` to ensure that we are getting the CUDA major version and not the driver version

Closes #145.