### PR TITLE
Remove cuda core dependency and switch back to pynvml

### DIFF
--- a/conda/recipes/rapids-cli/recipe.yaml
+++ b/conda/recipes/rapids-cli/recipe.yaml
@@ -31,8 +31,6 @@ requirements:
   run:
     - python
     - importlib-metadata >=4.13.0
-    - cuda-bindings >=12.9.6,!=13.0.*,!=13.1.*
-    - cuda-core >=0.6.0
     - cuda-pathfinder >=1.2.3
     - nvidia-ml-py >=12.0
     - packaging

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -61,11 +61,6 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cuda-core >=0.6.0
-          # NVML APIs we use via cuda.core.system landed in cuda-bindings
-          # 12.9.6 (CUDA 12) and 13.2.0 (CUDA 13). The 13.0/13.1
-          # wheels pre-date the 13.x landing and are excluded.
-          - cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*
           - nvidia-ml-py>=12.0
           - cuda-pathfinder >=1.2.3
           - packaging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,6 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "cuda-bindings>=12.9.6,!=13.0.*,!=13.1.*",
-    "cuda-core >=0.6.0",
     "cuda-pathfinder >=1.2.3",
     "importlib-metadata >= 4.13.0; python_version < '3.12'",
     "nvidia-ml-py>=12.0",

--- a/rapids_cli/doctor/checks/cuda_toolkit.py
+++ b/rapids_cli/doctor/checks/cuda_toolkit.py
@@ -108,6 +108,13 @@ def _ctypes_cuda_version(cudart_path: str) -> int | None:
     return None
 
 
+def _get_driver_cuda_major() -> int:
+    """Return the CUDA major version supported by the GPU driver."""
+    from rapids_cli.providers import get_gpu_info
+
+    return get_gpu_info().cuda_driver_version // 1000
+
+
 def _get_toolkit_cuda_major(cudart_path: str | None = None) -> int | None:
     """Return the CUDA major version of the toolkit.
 
@@ -158,7 +165,6 @@ def _check_path_version(label: str, path: Path, driver_major: int) -> None:
 def _gather_toolkit_info() -> CudaToolkitInfo:  # pragma: no cover
     """Gather CUDA toolkit and driver information from the real system."""
     import cuda.pathfinder
-    from cuda.core.system import get_driver_version
     from cuda.pathfinder import DynamicLibNotFoundError
 
     info = CudaToolkitInfo()
@@ -174,7 +180,7 @@ def _gather_toolkit_info() -> CudaToolkitInfo:  # pragma: no cover
             info.missing_libs.append(soname)
 
     try:
-        info.driver_major = get_driver_version()[0]
+        info.driver_major = _get_driver_cuda_major()
     except Exception:
         info.driver_major = None
 

--- a/rapids_cli/tests/test_cuda_toolkit.py
+++ b/rapids_cli/tests/test_cuda_toolkit.py
@@ -9,9 +9,11 @@ from rapids_cli.doctor.checks.cuda_toolkit import (
     CudaToolkitInfo,
     _ctypes_cuda_version,
     _gather_toolkit_info,
+    _get_driver_cuda_major,
     _get_toolkit_cuda_major,
     cuda_toolkit_check,
 )
+from rapids_cli.tests.fakes import FakeGpuInfo
 
 
 def _make_info(**overrides):
@@ -67,6 +69,11 @@ def test_ctypes_cuda_version_oserror():
     """ctypes returns None when the library can't be loaded."""
     with patch("ctypes.CDLL", side_effect=OSError("not found")):
         assert _ctypes_cuda_version("/nonexistent/libcudart.so") is None
+
+
+def test_get_driver_cuda_major_uses_gpu_info_provider(set_gpu_info):
+    set_gpu_info(FakeGpuInfo(cuda_driver_version=13020))
+    assert _get_driver_cuda_major() == 13
 
 
 # Check function tests


### PR DESCRIPTION
Following up on https://github.com/rapidsai/rapids-cli/pull/146#issuecomment-4509756538, usage of `cuda-core` has a specific pin on `cuda-bindings` version which has different versions for CUDA 12 and CUDA 13. 

While `cuda-bindings` itself is backward compatible, this pin is causing issues on other environments where tools like `pytorch` have their own versioning requirements for `cuda-bindings`. 

By switching back to using `pynvml` for GPU information, we can ensure that `rapids-cli` is supported on diverse environments without the need for specialized wheels