### PR TITLE
add wheel publishing to pypi

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
       build_type: branch
       package-name: rapids-cli
       package-type: python
+      publish_to_pypi: true
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
This PR sets the `publish_to_pypi` input on the wheels-publish shared workflow to automate wheel publishing to `pypi.org` on each release