### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,7 @@ jobs:
       package-name: rapids-cli
       package-type: python
       publish_to_pypi: true
+      publish-wheel-search-key: rapids-cli_wheel_python_rapids-cli
     permissions:
       actions: read
       contents: read

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -29,5 +29,5 @@ rattler-build build                   \
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
 # set package name so it is picked up by the shared-workflow for artifact naming
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python rapids-cli --pure)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python rapids-cli rapids-cli --pure --arch any)"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -12,3 +12,6 @@ python -m pip wheel                     \
     .
 
 ci/validate_wheel.sh "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python rapids-cli rapids-cli --pure --arch any)"
+export RAPIDS_PACKAGE_NAME

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -7,7 +7,7 @@ set -euo pipefail
 . /opt/conda/etc/profile.d/conda.sh
 
 rapids-logger "Downloading artifacts from previous jobs"
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name conda_python rapids-cli --pure)")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python rapids-cli rapids-cli --pure --arch any)")
 
 # ensure we always install the just-built-in-CI package, instead of falling back to earlier ones
 conda config --set channel_priority strict

--- a/ci/test_wheel.sh
+++ b/ci/test_wheel.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # nx-cugraph is a pure wheel, which is part of generating the download path
-WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="rapids-cli" RAPIDS_PY_WHEEL_PURE="1" rapids-download-wheels-from-github python)
+WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python rapids-cli rapids-cli --pure --arch any)")
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270