### PR TITLE
ensure nightly builds always produce new packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,12 @@ jobs:
   build-details:
     uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   conda-python-build:
+    needs: [build-details]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: branch
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       pure-conda: true
     permissions:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,8 @@ jobs:
       needs: ${{ toJSON(needs) }}
     permissions:
       contents: read
+  build-details:
+    uses: rapidsai/shared-workflows/.github/workflows/compute-build-details.yaml@main
   checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,11 +36,12 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   conda-python-build:
-    needs: [checks]
+    needs: [build-details, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/conda-python-build.yaml@main
     with:
       build_type: pull-request
+      build-datetime: ${{ needs.build-details.outputs.build-datetime }}
       script: ci/build_python.sh
       pure-conda: true
     permissions:

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-source rapids-date-string
+source rapids-datetime-string
 
 rapids-print-env
 

--- a/conda/recipes/rapids-cli/recipe.yaml
+++ b/conda/recipes/rapids-cli/recipe.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 context:
   version: ${{ env.get("RAPIDS_PACKAGE_VERSION") }}
   minor_version: ${{ (version | split("."))[:2] | join(".") }}
-  date_string: '${{ env.get("RAPIDS_DATE_STRING") }}'
+  datetime_string: '${{ env.get("RAPIDS_DATETIME_STRING") }}'
   head_rev: '${{ git.head_rev(".")[:8] }}'
 
 package:
@@ -17,7 +17,7 @@ source:
 
 build:
   noarch: python
-  string: ${{ date_string }}_${{ head_rev }}
+  string: ${{ datetime_string }}_${{ head_rev }}
   script:
     content: |
       python -m pip install -v .


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

* uses the new patterns for versioning nightly packages (see https://github.com/rapidsai/shared-workflows/pull/603), to ensure they're always uploaded on new builds.

For conda:

```text
# before
26.10.0a55[build=cuda12_260803_9da146ef]

# after
26.10.0a55[build=cuda12_260803200854_9da146ef]
```

For wheels:

**unchanged**. Unlike most other projects in this series, `rapids-cli` is using `hatchling version` for its nightly wheel versions and doesn't have scheduled nightly builds (only on new commits / tags), so doesn't face the same problems as most other RAPIDS projects with needing to upload new packages from an already-built commit:

<img width="405" height="194" alt="image" src="https://github.com/user-attachments/assets/19eb35e8-2a3e-40de-a1de-275f1fa202ac" />

https://pypi.anaconda.org/rapidsai-wheels-nightly/simple/rapids-cli/

## Notes for Reviewers

### How I tested this

See https://github.com/rapidsai/cugraph-gnn/pull/508
